### PR TITLE
framework-tests: fixes so it compiles

### DIFF
--- a/framework-tests/app/build.gradle
+++ b/framework-tests/app/build.gradle
@@ -11,13 +11,13 @@ allprojects {
 
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 22
     buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "org.gearvrf.tester"
         minSdkVersion 19
-        targetSdkVersion 23
+        targetSdkVersion 22
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
@@ -43,8 +43,8 @@ android {
 }
 
 dependencies {
-    compile(name:'framework-debug', ext:'aar')
-	compile(name: 'backend_oculus-debug', ext: 'aar')
+    compile(name: 'framework-debug', ext: 'aar')
+    compile(name: 'backend_oculus-debug', ext: 'aar')
     androidTestCompile 'com.android.support:support-annotations:23.0.1'
     androidTestCompile 'com.android.support.test:runner:0.4.1'
     androidTestCompile 'com.android.support.test:rules:0.4.1'

--- a/framework-tests/app/src/androidTest/java/org/gearvrf/tester/AssetTests.java
+++ b/framework-tests/app/src/androidTest/java/org/gearvrf/tester/AssetTests.java
@@ -15,6 +15,8 @@ import org.gearvrf.scene_objects.GVRModelSceneObject;
 import org.gearvrf.GVRPhongShader;
 import org.gearvrf.IAssetEvents;
 
+import org.gearvrf.unittestutils.GVRTestUtils;
+import org.gearvrf.unittestutils.GVRTestableActivity;
 import org.gearvrf.utility.FileNameUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -101,7 +103,7 @@ public class AssetTests
     };
 
     @Rule
-    public ActivityTestRule<TestableActivity> ActivityRule = new ActivityTestRule<TestableActivity>(TestableActivity.class)
+    public ActivityTestRule<GVRTestableActivity> ActivityRule = new ActivityTestRule<GVRTestableActivity>(GVRTestableActivity.class)
     {
         protected void afterActivityFinished() {
             mTestUtils.getMainScene().clear();

--- a/framework-tests/app/src/androidTest/java/org/gearvrf/tester/LightTests.java
+++ b/framework-tests/app/src/androidTest/java/org/gearvrf/tester/LightTests.java
@@ -44,7 +44,10 @@ public class LightTests
             ActivityTestRule<GVRTestableActivity>(GVRTestableActivity.class)
     {
         protected void afterActivityFinished() {
-            mTestUtils.getMainScene().clear();
+            final GVRScene mainScene = mTestUtils.getMainScene();
+            if (null != mainScene) {
+                mainScene.clear();
+            }
         }
     };
 

--- a/framework-tests/app/src/androidTest/java/org/gearvrf/tester/PickerTests.java
+++ b/framework-tests/app/src/androidTest/java/org/gearvrf/tester/PickerTests.java
@@ -20,6 +20,8 @@ import org.gearvrf.IPickEvents;
 import org.gearvrf.scene_objects.GVRCubeSceneObject;
 import org.gearvrf.scene_objects.GVRSphereSceneObject;
 import org.gearvrf.GVRPhongShader;
+import org.gearvrf.unittestutils.GVRTestUtils;
+import org.gearvrf.unittestutils.GVRTestableActivity;
 import org.gearvrf.utility.Log;
 import org.joml.Vector3f;
 import org.junit.Before;
@@ -227,7 +229,7 @@ public class PickerTests
     }
 
     @Rule
-    public ActivityTestRule<TestableActivity> ActivityRule = new ActivityTestRule<TestableActivity>(TestableActivity.class)
+    public ActivityTestRule<GVRTestableActivity> ActivityRule = new ActivityTestRule<GVRTestableActivity>(GVRTestableActivity.class)
     {
         protected void afterActivityFinished() {
             gvrTestUtils.getMainScene().clear();

--- a/framework-tests/app/src/androidTest/java/org/gearvrf/tester/SceneObjectTests.java
+++ b/framework-tests/app/src/androidTest/java/org/gearvrf/tester/SceneObjectTests.java
@@ -19,6 +19,8 @@ import org.gearvrf.scene_objects.GVRCylinderSceneObject;
 import org.gearvrf.scene_objects.GVRSphereSceneObject;
 import org.gearvrf.GVRPhongShader;
 import org.gearvrf.scene_objects.GVRTextViewSceneObject;
+import org.gearvrf.unittestutils.GVRTestUtils;
+import org.gearvrf.unittestutils.GVRTestableActivity;
 import org.joml.Vector3f;
 import org.junit.Before;
 import org.junit.Rule;
@@ -42,7 +44,7 @@ public class SceneObjectTests
 
 
     @Rule
-    public ActivityTestRule<TestableActivity> ActivityRule = new ActivityTestRule<TestableActivity>(TestableActivity.class)
+    public ActivityTestRule<GVRTestableActivity> ActivityRule = new ActivityTestRule<GVRTestableActivity>(GVRTestableActivity.class)
     {
         protected void afterActivityFinished() {
             mTestUtils.getMainScene().clear();

--- a/framework-tests/build.gradle
+++ b/framework-tests/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.0'
     }
 }
 

--- a/framework-tests/gradle/wrapper/gradle-wrapper.properties
+++ b/framework-tests/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 19 18:16:14 PDT 2016
+#Tue Sep 27 08:38:15 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/gvr-unittestutils/build.gradle
+++ b/gvr-unittestutils/build.gradle
@@ -11,12 +11,12 @@ allprojects {
 
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 22
     buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 23
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
     }
@@ -29,7 +29,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile(name:'framework-debug', ext:'aar')
+    compile fileTree(include: ['*.jar'], dir: 'libs')
+    compile(name: 'framework-debug', ext: 'aar')
     compile 'net.jodah:concurrentunit:0.4.2'
 }


### PR DESCRIPTION
also target api should 22 or less; otherwise the tests will have to ask
for read/write permissions at runtime; try running on a newer phone if
my explanation doesn't make sense