### PR TITLE
Fixed the picking tests

### DIFF
--- a/framework-tests/app/src/androidTest/java/org/gearvrf/tester/PickerTests.java
+++ b/framework-tests/app/src/androidTest/java/org/gearvrf/tester/PickerTests.java
@@ -11,6 +11,7 @@ import org.gearvrf.GVRFrustumPicker;
 import org.gearvrf.GVRMaterial;
 import org.gearvrf.GVRMesh;
 import org.gearvrf.GVRMeshCollider;
+import org.gearvrf.GVRObjectPicker;
 import org.gearvrf.GVRPicker;
 //import org.gearvrf.GVRObjectPicker;
 import org.gearvrf.GVRRenderData;
@@ -244,10 +245,6 @@ public class PickerTests
         mWaiter = new Waiter();
         gvrTestUtils.waitForOnInit();
         GVRContext context = gvrTestUtils.getGvrContext();
-        GVRScene scene = gvrTestUtils.getMainScene();
-
-        //Freeze the camera rig so that the hit positions are accurate and predictable.
-        scene.getMainCameraRig().setCameraRigType(GVRCameraRig.GVRCameraRigType.Freeze.ID);
 
         mBlue = new GVRMaterial(context, GVRMaterial.GVRShaderType.BeingGenerated.ID);
         mBlue.setDiffuseColor(0, 0, 1, 1);
@@ -539,7 +536,7 @@ public class PickerTests
         mPickHandler.checkHits("sphere", new Vector3f[] { new Vector3f(-1, 0, 0) }, null);
         mWaiter.resume();
     }
-/*
+
     @Test
     public void canPickWithObject()
     {
@@ -581,5 +578,4 @@ public class PickerTests
         mPickHandler.checkNoHits("sphere2");
         mWaiter.resume();
     }
-    */
 }

--- a/framework-tests/app/src/androidTest/java/org/gearvrf/tester/PickerTests.java
+++ b/framework-tests/app/src/androidTest/java/org/gearvrf/tester/PickerTests.java
@@ -5,6 +5,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 import net.jodah.concurrentunit.Waiter;
 
+import org.gearvrf.GVRCameraRig;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRFrustumPicker;
 import org.gearvrf.GVRMaterial;
@@ -243,6 +244,10 @@ public class PickerTests
         mWaiter = new Waiter();
         gvrTestUtils.waitForOnInit();
         GVRContext context = gvrTestUtils.getGvrContext();
+        GVRScene scene = gvrTestUtils.getMainScene();
+
+        //Freeze the camera rig so that the hit positions are accurate and predictable.
+        scene.getMainCameraRig().setCameraRigType(GVRCameraRig.GVRCameraRigType.Freeze.ID);
 
         mBlue = new GVRMaterial(context, GVRMaterial.GVRShaderType.BeingGenerated.ID);
         mBlue.setDiffuseColor(0, 0, 1, 1);
@@ -421,23 +426,26 @@ public class PickerTests
         scene.addSceneObject(sphere);
         scene.addSceneObject(box);
 
+        gvrTestUtils.waitForSceneRendering();
+
+        //test picking after the scene is rendered
         GVRPicker.GVRPickedObject picked[] = GVRPicker.pickObjects(scene, null, 0, 0, 0, 0, 0, -1.0f);
         Log.d("Picker", "testPickObjects");
-        gvrTestUtils.waitForSceneRendering();
+
         mWaiter.assertNotNull(picked);
         mWaiter.assertTrue(picked.length == 2);
         GVRPicker.GVRPickedObject hit1 = picked[0];
         GVRPicker.GVRPickedObject hit2 = picked[1];
         mWaiter.assertNotNull(hit1);
         mWaiter.assertEquals("box", hit1.hitObject.getName());
-        mWaiter.assertEquals(0, hit1.hitLocation[0]);
+        mWaiter.assertEquals(0.0f, hit1.hitLocation[0]);
         mWaiter.assertEquals(-0.25f, hit1.hitLocation[1]);
         mWaiter.assertEquals(0.5f, hit1.hitLocation[2]);
         mWaiter.assertNotNull(hit2);
         mWaiter.assertEquals("sphere", hit2.hitObject.getName());
-        mWaiter.assertEquals(0, hit2.hitLocation[0]);
-        mWaiter.assertEquals(0, hit2.hitLocation[1]);
-        mWaiter.assertEquals(-2, hit2.hitLocation[2]);
+        mWaiter.assertEquals(0.0f, hit2.hitLocation[0]);
+        mWaiter.assertEquals(0.0f, hit2.hitLocation[1]);
+        mWaiter.assertEquals(1.0f, hit2.hitLocation[2]);
 
         mWaiter.resume();
     }
@@ -460,7 +468,7 @@ public class PickerTests
         Log.d("Picker", "canPickObjectWithRay");
         float distance = GVRPicker.pickSceneObject(sphere1, scene.getMainCameraRig());
         gvrTestUtils.waitForSceneRendering();
-        mWaiter.assertEquals(1, distance);
+        mWaiter.assertEquals(1.0f, distance);
         mWaiter.resume();
     }
 

--- a/gvr-unittestutils/src/main/java/org/gearvrf/unittestutils/GVRTestableMain.java
+++ b/gvr-unittestutils/src/main/java/org/gearvrf/unittestutils/GVRTestableMain.java
@@ -19,6 +19,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 
 import org.gearvrf.GVRBitmapTexture;
+import org.gearvrf.GVRCameraRig;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRMain;
 import org.gearvrf.GVRScene;
@@ -41,6 +42,9 @@ class GVRTestableMain extends GVRMain{
     public void onInit(GVRContext gvrContext) {
         this.gvrContext = gvrContext;
         mainScene = gvrContext.getNextMainScene();
+
+        //Freeze the camera rig for the tests
+        mainScene.getMainCameraRig().setCameraRigType(GVRCameraRig.GVRCameraRigType.Freeze.ID);
         if (mainMonitor != null) {
             mainMonitor.onInitCalled(gvrContext, mainScene);
         } else {


### PR DESCRIPTION
Freeze the camera rig so that the hit positions are accurate
and predictable.

Fixed hit values from int to float

Also corrected expected values

GearVRf-DCO-1.0-Signed-off-by: Rahul Rudradevan
r.rudradevan@samsung.com