### PR TITLE
Automatically grant asset-tests permissions to access files

### DIFF
--- a/asset-tests/app/build.gradle
+++ b/asset-tests/app/build.gradle
@@ -76,3 +76,21 @@ dependencies {
     compile 'net.jodah:concurrentunit:0.4.2'
     compile project(path: ':gvr-unittestutils')
 }
+
+android.applicationVariants.all { variant ->
+    if (variant.getBuildType().name == "debug") {
+        task "configDevice${variant.name.capitalize()}" (type: Exec){
+            dependsOn variant.install
+
+            group = 'Device Configuration'
+            description = 'Grants android permissions before running the application.'
+
+            def adb = android.getAdbExe().toString()
+            def permissions = [ 'android.permission.READ_EXTERNAL_STORAGE','android.permission.WRITE_EXTERNAL_STORAGE']
+            for ( permission in permissions ) {
+                commandLine "$adb shell pm grant ${variant.applicationId} $permission".split(' ')
+            }
+        }
+        variant.testVariant.connectedInstrumentTest.dependsOn "configDevice${variant.name.capitalize()}"
+    }
+}


### PR DESCRIPTION
Code copied from framework-tests. Saves a bunch of manual clicks during automated test runs.