### PR TITLE
Make asset tests work with default GVRfAppTheme

### DIFF
--- a/asset-tests/app/src/main/AndroidManifest.xml
+++ b/asset-tests/app/src/main/AndroidManifest.xml
@@ -32,8 +32,7 @@
         tools:replace="android:icon"
         android:allowBackup="true"
         android:icon="@drawable/gearvr_logo"
-        android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:label="@string/app_name">
         <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
         <activity
             android:name="org.gearvrf.unittestutils.GVRTestableActivity"


### PR DESCRIPTION
Fix manifest for Samsung/GearVRf#1440