### PR TITLE
Updated X3D demo due to change of default Box size.

### DIFF
--- a/x3d/Scripting_Per_Frame/JavaScript_PerFrame_05_LightControls.x3d
+++ b/x3d/Scripting_Per_Frame/JavaScript_PerFrame_05_LightControls.x3d
@@ -73,7 +73,7 @@
               <Appearance>
                 <Material DEF="RedControllerMaterial" diffuseColor='.4 0 0' emissiveColor='1 0 0' specularColor='.1 0 0'/>
               </Appearance>
-              <Box/>
+              <Box size='.7 .7 .7'/>
             </Shape>
           </Transform>
         </Transform>
@@ -86,7 +86,7 @@
               <Appearance>
                 <Material DEF="GreenControllerMaterial" diffuseColor='0 .4 0' emissiveColor='0 .6 0'/>
               </Appearance>
-              <Box/>
+              <Box size='.7 .7 .7'/>
             </Shape>
           </Transform>
       </Transform>
@@ -98,7 +98,7 @@
               <Appearance>
                 <Material DEF="BlueControllerMaterial" diffuseColor='0 0 .4' emissiveColor='0 0 .6'/>
               </Appearance>
-              <Box/>
+              <Box size='.7 .7 .7'/>
             </Shape>
           </Transform>
       </Transform>


### PR DESCRIPTION
&lt;Box _size='.7 .7 .7'_/&gt; added since default Box value in X3D is larger and boxes were overlapping in the scene.

GearVRF DCO signed off by: Mitch Williams
m1.williams@partner.samsung.com