### PR TITLE
Wait/Notify fixes

### DIFF
--- a/gvr-unittestutils/src/main/java/org/gearvrf/unittestutils/GVRTestUtils.java
+++ b/gvr-unittestutils/src/main/java/org/gearvrf/unittestutils/GVRTestUtils.java
@@ -160,9 +160,9 @@ public class GVRTestUtils implements GVRMainMonitor {
      * @param frames number of frames to wait for
      */
     public void waitForXFrames(int frames) {
-        mFramesLockDone = false;
-        testableMain.notifyAfterXFrames(frames);
         synchronized (xFramesLock) {
+            mFramesLockDone = false;
+            testableMain.notifyAfterXFrames(frames);
             while(!mFramesLockDone) {
                 try {
                     xFramesLock.wait();

--- a/gvr-unittestutils/src/main/java/org/gearvrf/unittestutils/GVRTestableMain.java
+++ b/gvr-unittestutils/src/main/java/org/gearvrf/unittestutils/GVRTestableMain.java
@@ -47,11 +47,13 @@ class GVRTestableMain extends GVRMain{
         //Freeze the camera rig for the tests
         mainScene.getMainCameraRig().setCameraRigType(GVRCameraRig.GVRCameraRigType.Freeze.ID);
         synchronized (waitForMonitor) {
-            if(mainMonitor == null) {
+            while(mainMonitor == null) {
                 try {
                     waitForMonitor.wait();
                 } catch (InterruptedException e) {
                     Log.e(TAG,"Interrupted wait for main monitor");
+                    Thread.currentThread().interrupt();
+                    return;
                 }
             }
         }
@@ -64,7 +66,7 @@ class GVRTestableMain extends GVRMain{
         synchronized (waitXFramesLock) {
             if (waitForXFrames != WAIT_DISABLED) {
                 framesRendered++;
-                if (framesRendered == waitForXFrames) {
+                if (framesRendered >= waitForXFrames) {
                     mainMonitor.xFramesRendered();
                     waitForXFrames = WAIT_DISABLED;
                     framesRendered = 0;


### PR DESCRIPTION
1. Never assume that wait() exits up only after notify(). Beware spurious wake-ups. Java language spec recommens "using wait only within loops that terminate only when some logical condition that the thread is waiting for holds." in the "Wait Sets and Notification" section.

2. Reset thread interruption status after catching InterruptedException.