### PR TITLE
Simplify runtest script

### DIFF
--- a/scripts/runtest
+++ b/scripts/runtest
@@ -91,6 +91,18 @@ run-tests() {
 		do
 			run-single-test < /dev/null # adb sometimes consumes all input breaking the loop
 		done <<end-of-list
+			framework-tests all
+			asset-tests all
+end-of-list
+	)
+}
+
+run-tests4() {
+	(
+		while read TEST_GROUP TEST_NAME SUBTEST_NAME
+		do
+			run-single-test < /dev/null # adb sometimes consumes all input breaking the loop
+		done <<end-of-list
 			framework-tests BoundingVolumeTests
 			framework-tests CullTests
 			framework-tests LightTests


### PR DESCRIPTION
No need to run tests individually after memory leak fixes.
Tested on Note8. The ultimate test will be on Note4, and it is not done yet,
so keep the old version under new name 'run-tests4'