### PR TITLE
asset-tests: make the release variant non-debuggable

### DIFF
--- a/asset-tests/app/build.gradle
+++ b/asset-tests/app/build.gradle
@@ -28,8 +28,6 @@ android {
             jniDebuggable = true
         }
         release {
-            debuggable = true
-            jniDebuggable = true
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }


### PR DESCRIPTION
Supposed to fix a problem if you have gvr-simplesample and asset-tests in the same workspace