### PR TITLE
Added GVRTestUtils.screenShotRight, made tearDown() consistent

### DIFF
--- a/framework-tests/app/src/androidTest/java/org/gearvrf/tester/PickerTests.java
+++ b/framework-tests/app/src/androidTest/java/org/gearvrf/tester/PickerTests.java
@@ -26,6 +26,7 @@ import org.gearvrf.utility.Log;
 import org.joml.Matrix4f;
 import org.joml.Vector2f;
 import org.joml.Vector3f;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,13 +51,14 @@ public class PickerTests
     }
 
     @Rule
-    public ActivityTestRule<GVRTestableActivity> ActivityRule = new ActivityTestRule<GVRTestableActivity>(GVRTestableActivity.class)
+    public ActivityTestRule<GVRTestableActivity> ActivityRule = new ActivityTestRule<GVRTestableActivity>(GVRTestableActivity.class);
+
+    @After
+    public void tearDown()
     {
-        protected void afterActivityFinished() {
-            GVRScene scene = gvrTestUtils.getMainScene();
-            if (scene != null) {
-                scene.clear();
-            }
+        GVRScene scene = gvrTestUtils.getMainScene();
+        if (scene != null) {
+            scene.clear();
         }
     };
 

--- a/framework-tests/app/src/androidTest/java/org/gearvrf/tester/SceneObjectTests.java
+++ b/framework-tests/app/src/androidTest/java/org/gearvrf/tester/SceneObjectTests.java
@@ -22,6 +22,7 @@ import org.gearvrf.unittestutils.GVRTestUtils;
 import org.gearvrf.unittestutils.GVRTestableActivity;
 import org.gearvrf.utility.Log;
 import org.joml.Vector3f;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Rule;
@@ -46,15 +47,17 @@ public class SceneObjectTests
     private boolean mDoCompare = true;
 
     @Rule
-    public ActivityTestRule<GVRTestableActivity> ActivityRule = new ActivityTestRule<GVRTestableActivity>(GVRTestableActivity.class)
+    public ActivityTestRule<GVRTestableActivity> ActivityRule = new ActivityTestRule<GVRTestableActivity>(GVRTestableActivity.class);
+
+    @After
+    public void tearDown()
     {
-        protected void afterActivityFinished() {
-            GVRScene scene = mTestUtils.getMainScene();
-            if (scene != null) {
-                scene.clear();
-            }
+        GVRScene scene = mTestUtils.getMainScene();
+        if (scene != null)
+        {
+            scene.clear();
         }
-    };
+    }
 
     @Before
     public void setUp() throws Exception

--- a/framework-tests/app/src/androidTest/java/org/gearvrf/tester/TextureTests.java
+++ b/framework-tests/app/src/androidTest/java/org/gearvrf/tester/TextureTests.java
@@ -24,6 +24,7 @@ import org.gearvrf.scene_objects.GVRCubeSceneObject;
 import org.gearvrf.scene_objects.GVRTextViewSceneObject;
 import org.gearvrf.utility.Log;
 import org.joml.Vector3f;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,9 +45,17 @@ public class TextureTests
     private boolean mDoCompare = true;
 
     @Rule
-    public ActivityTestRule<GVRTestableActivity> ActivityRule = new ActivityTestRule<GVRTestableActivity>(GVRTestableActivity.class)
+    public ActivityTestRule<GVRTestableActivity> ActivityRule = new ActivityTestRule<GVRTestableActivity>(GVRTestableActivity.class);
+
+    @After
+    public void tearDown()
     {
-    };
+        GVRScene scene = mTestUtils.getMainScene();
+        if (scene != null)
+        {
+            scene.clear();
+        }
+    }
 
     @Before
     public void setUp() throws TimeoutException

--- a/framework-tests/app/src/androidTest/java/org/gearvrf/tester/TextureTransparencyTests.java
+++ b/framework-tests/app/src/androidTest/java/org/gearvrf/tester/TextureTransparencyTests.java
@@ -24,6 +24,7 @@ import org.gearvrf.scene_objects.GVRTextViewSceneObject;
 import org.gearvrf.unittestutils.GVRTestUtils;
 import org.gearvrf.unittestutils.GVRTestableActivity;
 import org.joml.Vector3f;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,9 +42,17 @@ public class TextureTransparencyTests
     private GVRSceneObject mRoot;
 
     @Rule
-    public ActivityTestRule<GVRTestableActivity> ActivityRule = new ActivityTestRule<GVRTestableActivity>(GVRTestableActivity.class)
+    public ActivityTestRule<GVRTestableActivity> ActivityRule = new ActivityTestRule<GVRTestableActivity>(GVRTestableActivity.class);
+
+    @After
+    public void tearDown()
     {
-    };
+        GVRScene scene = mTestUtils.getMainScene();
+        if (scene != null)
+        {
+            scene.clear();
+        }
+    }
 
     @Before
     public void setUp() throws TimeoutException

--- a/framework-tests/app/src/androidTest/java/org/gearvrf/tester/VideoTests.java
+++ b/framework-tests/app/src/androidTest/java/org/gearvrf/tester/VideoTests.java
@@ -138,6 +138,7 @@ public class VideoTests
             mWaiter.fail(ex);
         }
         gvrTestUtils.waitForAssetLoad();
+        gvrTestUtils.waitForXFrames(4);
         gvrTestUtils.screenShotRight(getClass().getSimpleName(), "testMonoVideo", mWaiter, mDoCompare);
     }
 
@@ -159,6 +160,7 @@ public class VideoTests
             mWaiter.fail(ex);
         }
         gvrTestUtils.waitForAssetLoad();
+        gvrTestUtils.waitForXFrames(4);
         gvrTestUtils.screenShotRight(getClass().getSimpleName(), "testMonoVideoMesh", mWaiter, mDoCompare);
     }
 
@@ -178,6 +180,7 @@ public class VideoTests
             mWaiter.fail(ex);
         }
         gvrTestUtils.waitForAssetLoad();
+        gvrTestUtils.waitForXFrames(4);
         gvrTestUtils.screenShotRight(getClass().getSimpleName(), "testHorizontalStereo", mWaiter, mDoCompare);
     }
 
@@ -197,6 +200,7 @@ public class VideoTests
             mWaiter.fail(ex);
         }
         gvrTestUtils.waitForAssetLoad();
+        gvrTestUtils.waitForXFrames(4);
         gvrTestUtils.screenShotRight(getClass().getSimpleName(), "testVerticalStereo", mWaiter, mDoCompare);
     }
 


### PR DESCRIPTION
GVRTestUtils.screenShotRight is needed by the video tests. Somehow I messed up and it didn't get included.
I also changed the tearDown() functions to be consistent across tests.

GearVRF DCO signed off by: Nola Donato nola.donatyo@samsung.com